### PR TITLE
updating node to latest LTS version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:12-alpine
 
 ADD views /app/views
 ADD package.json /app


### PR DESCRIPTION
Updating to active LTS version of node.js. Node 6 is no longer supported. 

https://nodejs.org/en/about/releases/