### PR TITLE
fix(Cloudant): Library not being loaded and pods failing in Kubernetes deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -167,6 +167,9 @@ if (appEnv.services['compose-for-mongodb'] || appEnv.getService(/.*[Mm][Oo][Nn][
      cloudant = Cloudant(appEnv.getService(/cloudant/).credentials);
   }
 } else if (process.env.CLOUDANT_URL){
+  // Load the Cloudant library.
+  var Cloudant = require('@cloudant/cloudant');
+
   cloudant = Cloudant(process.env.CLOUDANT_URL);
 }
 if(cloudant) {


### PR DESCRIPTION
When nodejs app is deployed in Kubernetes and uses the Cloudant DB it fails when trying to use credential URL
because the client library is not loaded for that code path.

Error shown by pod is similar to the followings:

```console
$ kubectl logs get-started-node-c689d597d-5btz9
> get-started-node@0.1.1 start /app
> node server.js

/app/server.js:177
  cloudant = Cloudant(process.env.CLOUDANT_URL);
             ^

TypeError: Cloudant is not a function

```

Fixes #23 which was previously closed by the OP.